### PR TITLE
Restore old PWD after finishing Cooja

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Try openning a simulation in *cooja* and see if it runs.
 If *cooja* fails to open the simulation and outputs an error in the console complaining about the size of `.text` file or something similar, download the *contiki.zip* file from **this** repository which contains the contiki directory from Instant Contiki 3.0 and test *cooja* in this version which is the same as the one used in this guide. Don't forget to checkout the submodules (`git submodule update --init`).
 
 ## Tips and tricks
-Instead of doing `cd /path/to/cooja` and then `ant run` each time you run *cooja*, you could create an *alias* in your `.bashrc` like this: `alias cooja='cd /path/to/cooja && ant run'`.
+Instead of doing `cd /path/to/cooja` and then `ant run` each time you run *cooja*, you could create an *alias* in your `.bashrc` like this: `alias cooja='sh -c "cd /path/to/cooja && ant run"'`.


### PR DESCRIPTION
Start Cooja in a separate shell. Thus changing directories won’t have
any effect on the original shell and the users is not in
`/path/to/cooja` after termination of Cooja but stays in the original
folder.